### PR TITLE
fix: omitted `$ref` parameters

### DIFF
--- a/src/writer.js
+++ b/src/writer.js
@@ -561,6 +561,8 @@ export const write = async (source, opts = {}) => {
   }
 
   function writeParameter(param) {
+    param = { ...param }
+
     if (!param.schema) {
       param.schema = {
         items: param.items,

--- a/test/index.js
+++ b/test/index.js
@@ -413,3 +413,19 @@ test('allOf test', async (t) => {
     }),
   ]))
 })
+
+test('parameter refs test', async (t) => {
+  await writeFile('./tmp/test-parameter-refs.yaml.js', await write('./test/test-parameter-refs.yaml'))
+  const { schema } = await import('../tmp/test-parameter-refs.yaml.js')
+  for (const path of ['/foo1', '/foo2']) {
+    assert.deepEqual(schema[path].GET.args, Type.Optional(
+      Type.Object({
+        query: Type.Optional(
+          Type.Object({
+            bar: Type.Optional(Type.String({ 'x-in': 'query' })),
+          })
+        ),
+      })
+    ))
+  }
+})

--- a/test/test-parameter-refs.yaml
+++ b/test/test-parameter-refs.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.3
+info:
+  description: Title
+  version: 1.0.0
+servers:
+  - url: https
+
+paths:
+  /foo1:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/query.bar'
+      responses:
+        '201':
+          description: Null response
+
+  /foo2:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/query.bar'
+      responses:
+        '201':
+          description: Null response
+
+components:
+  parameters:
+    query.bar:
+      name: bar
+      in: query
+      schema:
+        type: string


### PR DESCRIPTION
I noticed there are some cases where parameters using `$ref` were omitted. This happens due to deleting the `in` property from the parameter, which then means, if the parameter is shared, it not longer has an `in` property, and is excluded from subsequent codegen steps. To fix that, I copy `param` in `writeParameter`.

**Before this fix**

```ts
const schema = {
  '/foo1': {
    GET: {
      args: T.Optional(
        T.Object({
          query: T.Optional(
            T.Object({
              bar: T.Optional(T.String({ 'x-in': 'query' }))
            })
          )
        })
      ),
      data: T.Any({ 'x-status-code': '201' }),
      error: T.Union([T.Any({ 'x-status-code': 'default' })])
    }
  },
  '/foo2': {
    GET: {
      args: T.Void(),
      data: T.Any({ 'x-status-code': '201' }),
      error: T.Union([T.Any({ 'x-status-code': 'default' })])
    }
  }
}
```

**After this fix**

```ts
const schema = {
  '/foo1': {
    GET: {
      args: T.Optional(
        T.Object({
          query: T.Optional(
            T.Object({
              bar: T.Optional(T.String({ 'x-in': 'query' }))
            })
          )
        })
      ),
      data: T.Any({ 'x-status-code': '201' }),
      error: T.Union([T.Any({ 'x-status-code': 'default' })])
    }
  },
  '/foo2': {
    GET: {
      args: T.Optional(
        T.Object({
          query: T.Optional(
            T.Object({
              bar: T.Optional(T.String({ 'x-in': 'query' }))
            })
          )
        })
      ),
      data: T.Any({ 'x-status-code': '201' }),
      error: T.Union([T.Any({ 'x-status-code': 'default' })])
    }
  }
}
```