### PR TITLE
fix: don't strip const properties, they're valid in OpenAPI 3.1

### DIFF
--- a/src/cleanup.js
+++ b/src/cleanup.js
@@ -8,6 +8,7 @@ const validFields = new Set([
   'required',
   'pattern',
   'enum',
+  'const',
   'minimum',
   'maximum',
   'exclusiveMinimum',


### PR DESCRIPTION
Fixes #16 by adding `const` to allowed properties in the cleanup code.