### PR TITLE
fix: support nullable enums

### DIFF
--- a/src/writer.js
+++ b/src/writer.js
@@ -288,7 +288,9 @@ export const write = async (source, opts = {}) => {
     // TODO: use ref
     w.write('[')
     list.forEach((subSchema) => {
-      if (typeof subSchema !== 'object') {
+      if (subSchema === null) {
+        w.write('T.Null()')
+      } else if (typeof subSchema !== 'object') {
         w.write(`T.Literal(${JSON.stringify(subSchema)})`)
       } else {
         if (!('type' in subSchema)) {

--- a/test/index.js
+++ b/test/index.js
@@ -397,6 +397,7 @@ test('nullable test', async (t) => {
   assert.deepEqual(components.schemas.Test, Type.Union([Type.Null(), Type.Object({
     testStr: Type.Optional(Type.Union([Type.Null(), Type.String({ minLength: 2, maxLength: 2 })])),
     testArr: Type.Union([Type.Null(), Type.Array(Type.Number())]),
+    testEnum: Type.Union([Type.Null(), Type.Union([Type.Literal('foo'), Type.Literal('bar'), Type.Null()])]),
   })]))
 })
 

--- a/test/test-nullable.yaml
+++ b/test/test-nullable.yaml
@@ -12,6 +12,7 @@ components:
       nullable: true
       required:
         - testArr
+        - testEnum
       properties:
         testStr:
           type: string
@@ -24,4 +25,11 @@ components:
           description: Should be an array of numbers or null
           items:
             type: number
+          nullable: true
+        testEnum:
+          type: string
+          enum:
+            - foo
+            - bar
+            - null
           nullable: true


### PR DESCRIPTION
This fixes an error when handling nullable enums:

```yaml
testEnum:
  type: string
  enum:
    - foo
    - bar
    - null
  nullable: true
```

```
  TypeError [Error]: Cannot use 'in' operator to search for 'type' in null
      at file:///openapi-box/src/writer.js:294:22
      at Array.forEach (<anonymous>)
      at writeCompound (file:///openapi-box/src/writer.js:290:10)
      at writeType (file:///openapi-box/src/writer.js:176:7)
      at file:///openapi-box/src/writer.js:354:13
      at Array.forEach (<anonymous>)
      at file:///openapi-box/src/writer.js:351:24
      at CodeBlockWriter._indentBlockInternal (file:///openapi-box/node_modules/.pnpm/code-block-writer@13.0.3/node_modules/code-block-writer/esm/mod.js:261:13)
      at CodeBlockWriter.inlineBlock (file:///openapi-box/node_modules/.pnpm/code-block-writer@13.0.3/node_modules/code-block-writer/esm/mod.js:236:14)
      at writeObject (file:///openapi-box/src/writer.js:350:11)
```